### PR TITLE
refactor: submodules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +468,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "lazy_static",
  "serde",
  "tokio",
  "toml",

--- a/src/http_util/http_util.rs
+++ b/src/http_util/http_util.rs
@@ -1,1 +1,0 @@
-pub mod client;

--- a/src/license_management/license.rs
+++ b/src/license_management/license.rs
@@ -8,9 +8,9 @@ pub struct LicenseManager {
 }
 
 impl LicenseManager {
-    pub fn new(http_client: HttpClient) -> Self {
+    pub fn new() -> Self {
         LicenseManager {
-            http_client
+            http_client: HttpClient::new()
         }
     }
     pub async fn download_resource(&self, url: String) -> Result<String, String> {

--- a/src/license_management/license_management.rs
+++ b/src/license_management/license_management.rs
@@ -1,1 +1,0 @@
-pub mod license;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
-use crate::config::{Config, get_cfg};
-use crate::license::{License, LicenseManager};
-use crate::readme::get_cmd;
-use crate::http_util::client::HttpClient;
-use clap::Command;
-
-mod license;
-mod readme;
-mod config;
+mod license_management;
+mod readme_management;
 mod http_util;
+
+mod config;
+
+use crate::license::LicenseManager;
+use crate::license_management::license;
+use crate::readme_management::readme;
+
+use clap::Command;
 
 fn cli() -> Command {
     Command::new("")
@@ -24,10 +25,9 @@ fn cli() -> Command {
 
 fn main() {
 
-    let cfg = get_cfg().expect("config required");
+    let cfg = config::get_cfg().expect("config required");
 
-    let http_client = HttpClient::new();
-    let license_service = LicenseManager::new(http_client);
+    let license_service = LicenseManager::new();
 
     let matches = cli().get_matches();
 

--- a/src/readme_management/readme_management.rs
+++ b/src/readme_management/readme_management.rs
@@ -1,1 +1,0 @@
-pub mod readme;


### PR DESCRIPTION
* Organizes `http_util`, `license_management`, and `readme_management` in submodules
* One crate, with `main`and `config` at root level for now
* Some cleanup